### PR TITLE
Update the rails console command to use the binstub.

### DIFF
--- a/src/cloudforms-util.sh
+++ b/src/cloudforms-util.sh
@@ -3,7 +3,7 @@ CF_LOGS=/var/www/miq/vmdb/log
 export AUTO=${CF_LOGS}/automation.log
 export EVM=${CF_LOGS}/evm.log
 
-alias cf='echo "Starting CloudForms Console"; pushd /var/www/miq/vmdb; rails c; popd'
+alias cf='echo "Starting CloudForms Console"; pushd /var/www/miq/vmdb; bin/rails c; popd'
 alias log='cd $CF_LOGS'
 alias auto='less +F ${AUTO}'
 alias evm='less +F ${EVM}'


### PR DESCRIPTION
Without this, the command fails on CloudForms 4.1.
